### PR TITLE
Setting default locale for the console added.

### DIFF
--- a/EndPointController/EndPointController.cpp
+++ b/EndPointController/EndPointController.cpp
@@ -29,6 +29,7 @@ int _tmain(int argc, LPCWSTR argv[])
 	state.strDefaultDeviceID = '\0';
 	state.deviceStateFilter = DEVICE_STATE_ACTIVE;
 
+	setlocale(LC_ALL, "");
 	for (int i = 1; i < argc; i++) 
 	{
 		if (wcscmp(argv[i], _T("--help")) == 0)


### PR DESCRIPTION
Just one line that sets default system locale for the console. Without it devices with names in certain languages (like Russian or Japanese) were shown with question marks instead of letters.
